### PR TITLE
feat: scaffold SlideGit project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# powerpoimt_reviewer
+# powerpoint_reviewer
+
+Prototype project for SlideGit, a DB-less PPTX comparison and review tool.
+
+This repository contains a minimal Electron + React + TypeScript skeleton based on the project specification.
+
+## Development
+
+```
+npm install
+npm run dev
+```
+
+## Testing
+
+```
+npm test
+```

--- a/app/adapters/DriveAdapter.ts
+++ b/app/adapters/DriveAdapter.ts
@@ -1,0 +1,8 @@
+export interface DriveAdapter {
+  pickFile(): Promise<{ docId: string; name: string }>;
+  listRevisions(docId: string): Promise<Array<{ rev: number; createdAt: string; author?: string }>>;
+  getRevisionPptx(docId: string, rev: number): Promise<ArrayBuffer>;
+  readAppFile(docId: string, path: string): Promise<string | null>;
+  writeAppFile(docId: string, path: string, content: string): Promise<void>;
+  ensureAppFolder(docId: string): Promise<void>;
+}

--- a/app/adapters/SidecarStore.ts
+++ b/app/adapters/SidecarStore.ts
@@ -1,0 +1,10 @@
+import type { Manifest, RevGraph, Comments } from '../types';
+
+export interface SidecarStore {
+  loadManifest(docId: string, rev: number): Promise<Manifest | null>;
+  saveManifest(docId: string, manifest: Manifest): Promise<void>;
+  loadRevGraph(docId: string): Promise<RevGraph | null>;
+  saveRevGraph(docId: string, graph: RevGraph): Promise<void>;
+  loadComments(docId: string): Promise<Comments | null>;
+  saveComments(docId: string, comments: Comments): Promise<void>;
+}

--- a/app/adapters/SlackAdapter.ts
+++ b/app/adapters/SlackAdapter.ts
@@ -1,0 +1,11 @@
+export type SlackEvent = {
+  channel: string; user: string; text: string; ts: string;
+  thread_ts?: string;
+  files?: Array<{ url: string; name: string }>;
+};
+
+export interface SlackAdapter {
+  connect(token: string): Promise<void>;
+  watchChannels(channelIds: string[], onEvent: (e: SlackEvent) => void): void;
+  resolveMessageUrl(e: SlackEvent): string;
+}

--- a/app/core/DiffEngine.ts
+++ b/app/core/DiffEngine.ts
@@ -1,0 +1,26 @@
+import type { Manifest, ManifestElement } from '../types';
+
+export type SubChange = {
+  text?: { before: string; after: string; chunks: Array<{ op: '=' | '-' | '+', text: string }> };
+  image?: { beforeHash?: string; afterHash?: string };
+  style?: { before: any; after: any };
+  geom?: { before: any; after: any };
+};
+
+export type ElementChange =
+  | { type: 'added'; after: ManifestElement }
+  | { type: 'removed'; before: ManifestElement }
+  | { type: 'moved'; before: ManifestElement; after: ManifestElement }
+  | { type: 'edited'; before: ManifestElement; after: ManifestElement; sub: SubChange }
+  | { type: 'unchanged'; before: ManifestElement; after: ManifestElement };
+
+export type SlideDiff =
+  | { type: 'added'; indexNew: number }
+  | { type: 'removed'; indexOld: number }
+  | { type: 'moved'; indexOld: number; indexNew: number }
+  | { type: 'unchanged'; indexOld: number; indexNew: number }
+  | { type: 'edited'; indexOld: number; indexNew: number; elements: ElementChange[] };
+
+export interface DiffEngine {
+  diffManifests(a: Manifest, b: Manifest): SlideDiff[];
+}

--- a/app/core/PptxNormalizer.ts
+++ b/app/core/PptxNormalizer.ts
@@ -1,0 +1,11 @@
+import type { Manifest, ManifestElement } from '../types';
+
+export type NormalizedSlide = {
+  index: number;
+  elements: ManifestElement[];
+};
+
+export interface PptxNormalizer {
+  normalize(pptx: ArrayBuffer): Promise<NormalizedSlide[]>;
+  toManifest(docId: string, rev: number, slides: NormalizedSlide[]): Manifest;
+}

--- a/app/main.ts
+++ b/app/main.ts
@@ -1,0 +1,20 @@
+import { app, BrowserWindow } from 'electron';
+import path from 'path';
+
+async function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  await win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/app/preload.ts
+++ b/app/preload.ts
@@ -1,0 +1,3 @@
+import { contextBridge } from 'electron';
+
+contextBridge.exposeInMainWorld('api', {});

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,49 @@
+export type ElementKind = 'textbox' | 'image' | 'shape';
+
+export type ManifestElement = {
+  id: string;
+  kind: ElementKind;
+  geom: { x: number; y: number; w: number; h: number };
+  props: {
+    textNorm?: string;
+    styleKey?: string;
+    blobHash?: string;
+    shapeType?: string;
+  };
+};
+
+export type ManifestSlide = {
+  index: number;
+  hash: string;
+  titleText?: string;
+  elements: ManifestElement[];
+};
+
+export type Manifest = {
+  docId: string;
+  rev: number;
+  createdAt: string;
+  slideCount: number;
+  slides: ManifestSlide[];
+};
+
+export type RevGraph = {
+  nodes: Array<{ rev: number; label?: string; author?: string; createdAt?: string }>;
+  edges: Array<{ from: number; to: number; type: 'linear' | 'merge' | 'branch' }>;
+  pins: number[];
+};
+
+export type CommentLink = {
+  id: string;
+  rev: number;
+  slideIndex: number;
+  anchor?: string;
+  source: 'slack' | 'teams' | 'manual';
+  messageUrl: string;
+  ts?: string;
+  author?: string;
+  summary?: string;
+  createdAt: string;
+};
+
+export type Comments = { links: CommentLink[] };

--- a/app/ui/App.tsx
+++ b/app/ui/App.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import Timeline from './Timeline';
+
+function App() {
+  return (
+    <div>
+      <h1>SlideGit</h1>
+      <Timeline />
+    </div>
+  );
+}
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(<App />);
+}
+
+export default App;

--- a/app/ui/CommentPanel.tsx
+++ b/app/ui/CommentPanel.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CommentPanel: React.FC = () => {
+  return <div>CommentPanel placeholder</div>;
+};
+
+export default CommentPanel;

--- a/app/ui/DiffView.tsx
+++ b/app/ui/DiffView.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DiffView: React.FC = () => {
+  return <div>DiffView placeholder</div>;
+};
+
+export default DiffView;

--- a/app/ui/Timeline.tsx
+++ b/app/ui/Timeline.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Timeline: React.FC = () => {
+  return <div>Timeline placeholder</div>;
+};
+
+export default Timeline;

--- a/app/utils/crypto.ts
+++ b/app/utils/crypto.ts
@@ -1,0 +1,7 @@
+export async function sha256(data: ArrayBuffer | string): Promise<string> {
+  if (typeof data === 'string') {
+    data = new TextEncoder().encode(data);
+  }
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hash)).map(x => x.toString(16).padStart(2, '0')).join('');
+}

--- a/app/utils/xml.ts
+++ b/app/utils/xml.ts
@@ -1,0 +1,9 @@
+export function parseXml(xml: string): any {
+  // Placeholder for XML parsing
+  return {};
+}
+
+export function buildXml(obj: any): string {
+  // Placeholder for XML building
+  return '';
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SlideGit</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./app/ui/App.tsx"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "powerpoint_reviewer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "echo 'dev server placeholder'",
+    "build": "echo 'build placeholder'",
+    "test": "echo 'No tests configured'"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["app/**/*"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Electron + React + TypeScript skeleton for SlideGit
- add core interfaces for PPTX normalization, diff engine, and adapters
- stub basic UI components and utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0682ece883229a09964f9b917e5c