### PR TITLE
feat: add demo diff UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# powerpoimt_reviewer
+# powerpoint_reviewer
+
+Prototype project for SlideGit, a DB-less PPTX comparison and review tool.
+
+This repository contains a minimal Electron + React + TypeScript skeleton based on the project specification.
+
+## Core workflow
+
+The revision comparison flow is implemented in `app/core/compareTwoRevisions.ts`.
+It fetches PPTX revisions, builds manifests, computes diffs, and caches results
+through a pluggable `SidecarStore`. A filesystem-backed store implementation
+is provided at `app/adapters/FsSidecarStore.ts` for local development.
+
+For Slack integration, a polling adapter lives at
+`app/adapters/PollingSlackAdapter.ts`. It connects using a user-provided token
+and periodically fetches channel histories to surface messages that reference
+slides or elements.
+
+## Development
+
+```
+npm install
+npm run dev
+```
+
+After the dev server starts, open the app in your browser and click
+"サンプル差分を読み込む" to load demo manifests. The UI will display slide
+comparison results and a comment panel where additional Slack URLs can be
+added.
+
+## Testing
+
+```
+npm test
+```

--- a/app/adapters/DriveAdapter.ts
+++ b/app/adapters/DriveAdapter.ts
@@ -1,0 +1,8 @@
+export interface DriveAdapter {
+  pickFile(): Promise<{ docId: string; name: string }>;
+  listRevisions(docId: string): Promise<Array<{ rev: number; createdAt: string; author?: string }>>;
+  getRevisionPptx(docId: string, rev: number): Promise<ArrayBuffer>;
+  readAppFile(docId: string, path: string): Promise<string | null>;
+  writeAppFile(docId: string, path: string, content: string): Promise<void>;
+  ensureAppFolder(docId: string): Promise<void>;
+}

--- a/app/adapters/FsSidecarStore.ts
+++ b/app/adapters/FsSidecarStore.ts
@@ -1,0 +1,61 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { Manifest, RevGraph, Comments } from '../types';
+import type { SidecarStore } from './SidecarStore';
+
+/**
+ * A SidecarStore implementation that persists JSON files to the local
+ * filesystem. This is primarily for development and testing; the real app
+ * would use Google Drive's App Folder.
+ */
+export class FsSidecarStore implements SidecarStore {
+  constructor(private baseDir: string) {}
+
+  private docDir(docId: string): string {
+    return path.join(this.baseDir, docId);
+  }
+
+  private async readJson<T>(p: string): Promise<T | null> {
+    try {
+      const content = await fs.readFile(p, 'utf-8');
+      return JSON.parse(content) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeJson(p: string, data: any): Promise<void> {
+    await fs.mkdir(path.dirname(p), { recursive: true });
+    await fs.writeFile(p, JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  async loadManifest(docId: string, rev: number): Promise<Manifest | null> {
+    const p = path.join(this.docDir(docId), `manifest@rev-${rev}.json`);
+    return this.readJson<Manifest>(p);
+  }
+
+  async saveManifest(docId: string, manifest: Manifest): Promise<void> {
+    const p = path.join(this.docDir(docId), `manifest@rev-${manifest.rev}.json`);
+    await this.writeJson(p, manifest);
+  }
+
+  async loadRevGraph(docId: string): Promise<RevGraph | null> {
+    const p = path.join(this.docDir(docId), 'revgraph.json');
+    return this.readJson<RevGraph>(p);
+  }
+
+  async saveRevGraph(docId: string, graph: RevGraph): Promise<void> {
+    const p = path.join(this.docDir(docId), 'revgraph.json');
+    await this.writeJson(p, graph);
+  }
+
+  async loadComments(docId: string): Promise<Comments | null> {
+    const p = path.join(this.docDir(docId), 'comments.json');
+    return this.readJson<Comments>(p);
+  }
+
+  async saveComments(docId: string, comments: Comments): Promise<void> {
+    const p = path.join(this.docDir(docId), 'comments.json');
+    await this.writeJson(p, comments);
+  }
+}

--- a/app/adapters/PollingSlackAdapter.ts
+++ b/app/adapters/PollingSlackAdapter.ts
@@ -1,0 +1,59 @@
+import { WebClient } from '@slack/web-api';
+import type { SlackAdapter, SlackEvent } from './SlackAdapter';
+
+/**
+ * SlackAdapter implementation that polls conversations.history for new
+ * messages. This avoids RTM sockets and keeps the client-only nature of the
+ * MVP. It stores the latest timestamp per channel and periodically fetches
+ * new messages.
+ */
+export class PollingSlackAdapter implements SlackAdapter {
+  private client: WebClient | null = null;
+  private teamId: string | null = null;
+  private lastTs = new Map<string, string>();
+  private timers = new Map<string, ReturnType<typeof setInterval>>();
+
+  async connect(token: string): Promise<void> {
+    this.client = new WebClient(token);
+    const auth = await this.client.auth.test();
+    this.teamId = auth.team_id as string;
+  }
+
+  watchChannels(channelIds: string[], onEvent: (e: SlackEvent) => void): void {
+    if (!this.client) throw new Error('not connected');
+    for (const id of channelIds) {
+      this.pollChannel(id, onEvent);
+      const timer = setInterval(() => this.pollChannel(id, onEvent), 30000);
+      this.timers.set(id, timer);
+    }
+  }
+
+  private async pollChannel(channel: string, cb: (e: SlackEvent) => void) {
+    if (!this.client) return;
+    const oldest = this.lastTs.get(channel);
+    const res = await this.client.conversations.history({ channel, oldest });
+    if (!res.messages) return;
+    // messages are returned newest first; process oldest first
+    const msgs = [...res.messages].reverse();
+    for (const m of msgs) {
+      if (!m.ts) continue;
+      this.lastTs.set(channel, m.ts as string);
+      cb({
+        channel,
+        user: (m as any).user || '',
+        text: (m as any).text || '',
+        ts: m.ts as string,
+        thread_ts: (m as any).thread_ts,
+        files: ((m as any).files || []).map((f: any) => ({
+          url: f.url_private as string,
+          name: f.name as string
+        }))
+      });
+    }
+  }
+
+  resolveMessageUrl(e: SlackEvent): string {
+    const ts = e.ts.replace('.', '');
+    return `https://app.slack.com/client/${this.teamId}/${e.channel}/p${ts}`;
+  }
+}

--- a/app/adapters/SidecarStore.ts
+++ b/app/adapters/SidecarStore.ts
@@ -1,0 +1,10 @@
+import type { Manifest, RevGraph, Comments } from '../types';
+
+export interface SidecarStore {
+  loadManifest(docId: string, rev: number): Promise<Manifest | null>;
+  saveManifest(docId: string, manifest: Manifest): Promise<void>;
+  loadRevGraph(docId: string): Promise<RevGraph | null>;
+  saveRevGraph(docId: string, graph: RevGraph): Promise<void>;
+  loadComments(docId: string): Promise<Comments | null>;
+  saveComments(docId: string, comments: Comments): Promise<void>;
+}

--- a/app/adapters/SlackAdapter.ts
+++ b/app/adapters/SlackAdapter.ts
@@ -1,0 +1,11 @@
+export type SlackEvent = {
+  channel: string; user: string; text: string; ts: string;
+  thread_ts?: string;
+  files?: Array<{ url: string; name: string }>;
+};
+
+export interface SlackAdapter {
+  connect(token: string): Promise<void>;
+  watchChannels(channelIds: string[], onEvent: (e: SlackEvent) => void): void;
+  resolveMessageUrl(e: SlackEvent): string;
+}

--- a/app/core/DiffEngine.ts
+++ b/app/core/DiffEngine.ts
@@ -1,0 +1,161 @@
+import { diff_match_patch } from 'diff-match-patch';
+import type { Manifest, ManifestElement } from '../types';
+
+export type SubChange = {
+  text?: { before: string; after: string; chunks: Array<{ op: '=' | '-' | '+', text: string }> };
+  image?: { beforeHash?: string; afterHash?: string };
+  style?: { before: any; after: any };
+  geom?: { before: any; after: any };
+};
+
+export type ElementChange =
+  | { type: 'added'; after: ManifestElement }
+  | { type: 'removed'; before: ManifestElement }
+  | { type: 'moved'; before: ManifestElement; after: ManifestElement }
+  | { type: 'edited'; before: ManifestElement; after: ManifestElement; sub: SubChange }
+  | { type: 'unchanged'; before: ManifestElement; after: ManifestElement };
+
+export type SlideDiff =
+  | { type: 'added'; indexNew: number }
+  | { type: 'removed'; indexOld: number }
+  | { type: 'moved'; indexOld: number; indexNew: number }
+  | { type: 'unchanged'; indexOld: number; indexNew: number }
+  | { type: 'edited'; indexOld: number; indexNew: number; elements: ElementChange[] };
+
+export interface DiffEngine {
+  diffManifests(a: Manifest, b: Manifest): SlideDiff[];
+}
+
+/**
+ * Basic implementation of DiffEngine performing slide-level LCS matching and
+ * element-level diffing keyed by stable IDs.
+ */
+export class BasicDiffEngine implements DiffEngine {
+  diffManifests(a: Manifest, b: Manifest): SlideDiff[] {
+    const result: SlideDiff[] = [];
+    const oldHashes = a.slides.map((s) => s.hash);
+    const newHashes = b.slides.map((s) => s.hash);
+    const lcs = computeLcs(oldHashes, newHashes);
+
+    let i = 0;
+    let j = 0;
+    let k = 0;
+    while (i < a.slides.length || j < b.slides.length) {
+      if (
+        i < a.slides.length &&
+        j < b.slides.length &&
+        k < lcs.length &&
+        a.slides[i].hash === lcs[k] &&
+        b.slides[j].hash === lcs[k]
+      ) {
+        const indexOld = i;
+        const indexNew = j;
+        if (i === j) {
+          result.push({ type: 'unchanged', indexOld, indexNew });
+        } else {
+          result.push({ type: 'moved', indexOld, indexNew });
+        }
+        i++;
+        j++;
+        k++;
+      } else if (k < lcs.length && j < b.slides.length && b.slides[j].hash === lcs[k]) {
+        result.push({ type: 'removed', indexOld: i });
+        i++;
+      } else if (k < lcs.length && i < a.slides.length && a.slides[i].hash === lcs[k]) {
+        result.push({ type: 'added', indexNew: j });
+        j++;
+      } else if (i < a.slides.length && j < b.slides.length) {
+        const elements = diffElements(a.slides[i].elements, b.slides[j].elements);
+        result.push({ type: 'edited', indexOld: i, indexNew: j, elements });
+        i++;
+        j++;
+      } else if (j < b.slides.length) {
+        result.push({ type: 'added', indexNew: j });
+        j++;
+      } else if (i < a.slides.length) {
+        result.push({ type: 'removed', indexOld: i });
+        i++;
+      }
+    }
+
+    return result;
+  }
+}
+
+function computeLcs(a: string[], b: string[]): string[] {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      if (a[i] === b[j]) dp[i][j] = dp[i + 1][j + 1] + 1;
+      else dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const res: string[] = [];
+  let i = 0,
+    j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      res.push(a[i]);
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) i++;
+    else j++;
+  }
+  return res;
+}
+
+function diffElements(aEls: ManifestElement[], bEls: ManifestElement[]): ElementChange[] {
+  const result: ElementChange[] = [];
+  const mapB = new Map<string, ManifestElement>(bEls.map((e) => [e.id, e]));
+  const dmp = new diff_match_patch();
+
+  for (const eA of aEls) {
+    const eB = mapB.get(eA.id);
+    if (eB) {
+      mapB.delete(eA.id);
+      if (JSON.stringify(eA) === JSON.stringify(eB)) {
+        result.push({ type: 'unchanged', before: eA, after: eB });
+      } else {
+        const sub: SubChange = {};
+        if (eA.props.textNorm !== eB.props.textNorm) {
+          const diffs = dmp.diff_main(eA.props.textNorm || '', eB.props.textNorm || '');
+          dmp.diff_cleanupSemantic(diffs);
+          const chunks = diffs.map(([op, text]) => ({
+            op: op === 0 ? '=' : op === -1 ? '-' : '+',
+            text
+          }));
+          sub.text = {
+            before: eA.props.textNorm || '',
+            after: eB.props.textNorm || '',
+            chunks
+          };
+        }
+        if (eA.props.blobHash !== eB.props.blobHash) {
+          sub.image = { beforeHash: eA.props.blobHash, afterHash: eB.props.blobHash };
+        }
+        if (eA.props.styleKey !== eB.props.styleKey) {
+          sub.style = { before: eA.props.styleKey, after: eB.props.styleKey };
+        }
+        if (
+          eA.geom.x !== eB.geom.x ||
+          eA.geom.y !== eB.geom.y ||
+          eA.geom.w !== eB.geom.w ||
+          eA.geom.h !== eB.geom.h
+        ) {
+          sub.geom = { before: eA.geom, after: eB.geom };
+        }
+        result.push({ type: 'edited', before: eA, after: eB, sub });
+      }
+    } else {
+      result.push({ type: 'removed', before: eA });
+    }
+  }
+
+  for (const eB of mapB.values()) {
+    result.push({ type: 'added', after: eB });
+  }
+
+  return result;
+}

--- a/app/core/PptxNormalizer.ts
+++ b/app/core/PptxNormalizer.ts
@@ -1,0 +1,64 @@
+import JSZip from 'jszip';
+import type { Manifest, ManifestElement } from '../types';
+import { sha256 } from '../utils/crypto';
+
+export type NormalizedSlide = {
+  index: number;
+  elements: ManifestElement[];
+  hash: string;
+  titleText?: string;
+};
+
+export interface PptxNormalizer {
+  normalize(pptx: ArrayBuffer): Promise<NormalizedSlide[]>;
+  toManifest(docId: string, rev: number, slides: NormalizedSlide[]): Manifest;
+}
+
+/**
+ * Basic PPTX normalizer that extracts text boxes from slide XMLs and assigns
+ * content-based stable IDs. Geometry and styles are omitted for brevity but
+ * placeholders are returned to satisfy the Manifest schema.
+ */
+export class BasicPptxNormalizer implements PptxNormalizer {
+  async normalize(pptx: ArrayBuffer): Promise<NormalizedSlide[]> {
+    const zip = await JSZip.loadAsync(pptx);
+    const slideFiles = Object.keys(zip.files)
+      .filter((f) => f.startsWith('ppt/slides/slide') && f.endsWith('.xml'))
+      .sort();
+
+    const slides: NormalizedSlide[] = [];
+    for (let i = 0; i < slideFiles.length; i++) {
+      const xml = await zip.file(slideFiles[i])!.async('string');
+      const elements: ManifestElement[] = [];
+      const textMatches = [...xml.matchAll(/<a:t[^>]*>(.*?)<\/a:t>/g)];
+      for (const match of textMatches) {
+        const textNorm = match[1].replace(/\s+/g, ' ').trim();
+        const id = await sha256(`textbox|${textNorm}`);
+        elements.push({
+          id,
+          kind: 'textbox',
+          geom: { x: 0, y: 0, w: 0, h: 0 },
+          props: { textNorm }
+        });
+      }
+      const hash = await sha256(elements.map((e) => e.id).sort().join('|'));
+      slides.push({ index: i, elements, hash, titleText: elements[0]?.props.textNorm });
+    }
+    return slides;
+  }
+
+  toManifest(docId: string, rev: number, slides: NormalizedSlide[]): Manifest {
+    return {
+      docId,
+      rev,
+      createdAt: new Date().toISOString(),
+      slideCount: slides.length,
+      slides: slides.map((s) => ({
+        index: s.index,
+        hash: s.hash,
+        titleText: s.titleText,
+        elements: s.elements
+      }))
+    };
+  }
+}

--- a/app/core/compareTwoRevisions.ts
+++ b/app/core/compareTwoRevisions.ts
@@ -1,0 +1,62 @@
+import type { DriveAdapter } from '../adapters/DriveAdapter';
+import type { SidecarStore } from '../adapters/SidecarStore';
+import type { PptxNormalizer } from './PptxNormalizer';
+import type { DiffEngine, SlideDiff } from './DiffEngine';
+import type { Manifest } from '../types';
+
+/**
+ * Compare two revisions of a PPTX document.
+ *
+ * This orchestrates fetching PPTX binaries, building or loading manifests,
+ * computing diffs and caching results into the sidecar store.
+ */
+export async function compareTwoRevisions(
+  docId: string,
+  revA: number,
+  revB: number,
+  deps: {
+    drive: DriveAdapter;
+    normalizer: PptxNormalizer;
+    diff: DiffEngine;
+    sidecar: SidecarStore;
+  }
+): Promise<{ mA: Manifest; mB: Manifest; diffs: SlideDiff[] }> {
+  const { drive, normalizer, diff: diffEngine, sidecar } = deps;
+
+  // Fetch both revisions in parallel
+  const [pptxA, pptxB] = await Promise.all([
+    drive.getRevisionPptx(docId, revA),
+    drive.getRevisionPptx(docId, revB)
+  ]);
+
+  // Build or load manifests for each revision
+  const [mA, mB] = await Promise.all([
+    loadOrBuildManifest(docId, revA, pptxA, normalizer, sidecar),
+    loadOrBuildManifest(docId, revB, pptxB, normalizer, sidecar)
+  ]);
+
+  // Compute diffs
+  const diffs = diffEngine.diffManifests(mA, mB);
+
+  // Persist manifests for future runs
+  await Promise.all([
+    sidecar.saveManifest(docId, mA),
+    sidecar.saveManifest(docId, mB)
+  ]);
+
+  return { mA, mB, diffs };
+}
+
+async function loadOrBuildManifest(
+  docId: string,
+  rev: number,
+  pptx: ArrayBuffer,
+  normalizer: PptxNormalizer,
+  sidecar: SidecarStore
+): Promise<Manifest> {
+  const cached = await sidecar.loadManifest(docId, rev);
+  if (cached) return cached;
+
+  const slides = await normalizer.normalize(pptx);
+  return normalizer.toManifest(docId, rev, slides);
+}

--- a/app/main.ts
+++ b/app/main.ts
@@ -1,0 +1,20 @@
+import { app, BrowserWindow } from 'electron';
+import path from 'path';
+
+async function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  await win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/app/preload.ts
+++ b/app/preload.ts
@@ -1,0 +1,3 @@
+import { contextBridge } from 'electron';
+
+contextBridge.exposeInMainWorld('api', {});

--- a/app/sample/sampleData.ts
+++ b/app/sample/sampleData.ts
@@ -1,0 +1,94 @@
+import type { Manifest, Comments } from '../types';
+
+export const manifestA: Manifest = {
+  docId: 'demo',
+  rev: 1,
+  createdAt: '2023-01-01T00:00:00Z',
+  slideCount: 2,
+  slides: [
+    {
+      index: 0,
+      hash: 'slide-hello',
+      elements: [
+        {
+          id: 'txt-hello',
+          kind: 'textbox',
+          geom: { x: 0, y: 0, w: 100, h: 20 },
+          props: { textNorm: 'Hello' }
+        }
+      ]
+    },
+    {
+      index: 1,
+      hash: 'slide-img',
+      elements: [
+        {
+          id: 'img-1',
+          kind: 'image',
+          geom: { x: 0, y: 0, w: 100, h: 100 },
+          props: { blobHash: 'imgA' }
+        }
+      ]
+    }
+  ]
+};
+
+export const manifestB: Manifest = {
+  docId: 'demo',
+  rev: 2,
+  createdAt: '2023-01-02T00:00:00Z',
+  slideCount: 3,
+  slides: [
+    {
+      index: 0,
+      hash: 'slide-hello-mod',
+      elements: [
+        {
+          id: 'txt-hello',
+          kind: 'textbox',
+          geom: { x: 0, y: 0, w: 100, h: 20 },
+          props: { textNorm: 'Hello world' }
+        }
+      ]
+    },
+    {
+      index: 1,
+      hash: 'slide-img',
+      elements: [
+        {
+          id: 'img-1',
+          kind: 'image',
+          geom: { x: 0, y: 0, w: 100, h: 100 },
+          props: { blobHash: 'imgA' }
+        }
+      ]
+    },
+    {
+      index: 2,
+      hash: 'slide-new',
+      elements: [
+        {
+          id: 'shape-1',
+          kind: 'shape',
+          geom: { x: 10, y: 10, w: 50, h: 50 },
+          props: { shapeType: 'rect', styleKey: 'style1' }
+        }
+      ]
+    }
+  ]
+};
+
+export const sampleComments: Comments = {
+  links: [
+    {
+      id: 'c1',
+      rev: 2,
+      slideIndex: 0,
+      anchor: 'element:textbox:txt-hello',
+      source: 'manual',
+      messageUrl: 'https://slack.example.com/archives/C1/p111',
+      summary: '挨拶を更新',
+      createdAt: '2023-01-02T00:00:00Z'
+    }
+  ]
+};

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,49 @@
+export type ElementKind = 'textbox' | 'image' | 'shape';
+
+export type ManifestElement = {
+  id: string;
+  kind: ElementKind;
+  geom: { x: number; y: number; w: number; h: number };
+  props: {
+    textNorm?: string;
+    styleKey?: string;
+    blobHash?: string;
+    shapeType?: string;
+  };
+};
+
+export type ManifestSlide = {
+  index: number;
+  hash: string;
+  titleText?: string;
+  elements: ManifestElement[];
+};
+
+export type Manifest = {
+  docId: string;
+  rev: number;
+  createdAt: string;
+  slideCount: number;
+  slides: ManifestSlide[];
+};
+
+export type RevGraph = {
+  nodes: Array<{ rev: number; label?: string; author?: string; createdAt?: string }>;
+  edges: Array<{ from: number; to: number; type: 'linear' | 'merge' | 'branch' }>;
+  pins: number[];
+};
+
+export type CommentLink = {
+  id: string;
+  rev: number;
+  slideIndex: number;
+  anchor?: string;
+  source: 'slack' | 'teams' | 'manual';
+  messageUrl: string;
+  ts?: string;
+  author?: string;
+  summary?: string;
+  createdAt: string;
+};
+
+export type Comments = { links: CommentLink[] };

--- a/app/ui/App.tsx
+++ b/app/ui/App.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import Timeline from './Timeline';
+import DiffView from './DiffView';
+import CommentPanel from './CommentPanel';
+import { BasicDiffEngine } from '../core/DiffEngine';
+import type { SlideDiff } from '../core/DiffEngine';
+import type { Comments } from '../types';
+import { manifestA, manifestB, sampleComments } from '../sample/sampleData';
+
+function App() {
+  const [diffs, setDiffs] = useState<SlideDiff[] | null>(null);
+  const [comments, setComments] = useState<Comments>(sampleComments);
+
+  const loadDemo = () => {
+    const engine = new BasicDiffEngine();
+    const d = engine.diffManifests(manifestA, manifestB);
+    setDiffs(d);
+  };
+
+  const addComment = (url: string) => {
+    setComments((prev) => ({
+      links: [
+        ...prev.links,
+        {
+          id: `c${prev.links.length + 1}`,
+          rev: 2,
+          slideIndex: 0,
+          source: 'manual',
+          messageUrl: url,
+          createdAt: new Date().toISOString()
+        }
+      ]
+    }));
+  };
+
+  return (
+    <div>
+      <h1>SlideGit デモ</h1>
+      <Timeline onLoadDemo={loadDemo} />
+      {diffs && (
+        <>
+          <DiffView diffs={diffs} />
+          <CommentPanel comments={comments} onAdd={addComment} />
+        </>
+      )}
+    </div>
+  );
+}
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(<App />);
+}
+
+export default App;

--- a/app/ui/CommentPanel.tsx
+++ b/app/ui/CommentPanel.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import type { Comments } from '../types';
+
+type Props = {
+  comments: Comments;
+  onAdd: (url: string) => void;
+};
+
+const CommentPanel: React.FC<Props> = ({ comments, onAdd }) => {
+  const [url, setUrl] = useState('');
+
+  return (
+    <div>
+      <h3>Comments</h3>
+      <ul>
+        {comments.links.map((l) => (
+          <li key={l.id}>
+            <a href={l.messageUrl} target="_blank" rel="noreferrer">
+              {l.summary || l.messageUrl}
+            </a>
+          </li>
+        ))}
+      </ul>
+      <div>
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="Slack message URL"
+        />
+        <button
+          onClick={() => {
+            if (url.trim()) {
+              onAdd(url.trim());
+              setUrl('');
+            }
+          }}
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CommentPanel;

--- a/app/ui/DiffView.tsx
+++ b/app/ui/DiffView.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { SlideDiff } from '../core/DiffEngine';
+
+type Props = { diffs: SlideDiff[] };
+
+const DiffView: React.FC<Props> = ({ diffs }) => {
+  return (
+    <div>
+      <h3>差分結果</h3>
+      <ul>
+        {diffs.map((d, i) => (
+          <li key={i}>
+            {(() => {
+              switch (d.type) {
+                case 'added':
+                  return `スライド${d.indexNew}が追加`;
+                case 'removed':
+                  return `スライド${d.indexOld}が削除`;
+                case 'moved':
+                  return `スライド${d.indexOld}->${d.indexNew}に移動`;
+                case 'unchanged':
+                  return `スライド${d.indexOld}に変更なし`;
+                case 'edited':
+                  return `スライド${d.indexOld}が編集`; // element details omitted
+                default:
+                  return '';
+              }
+            })()}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DiffView;

--- a/app/ui/Timeline.tsx
+++ b/app/ui/Timeline.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+type Props = { onLoadDemo: () => void };
+
+const Timeline: React.FC<Props> = ({ onLoadDemo }) => {
+  return (
+    <div>
+      <button onClick={onLoadDemo}>サンプル差分を読み込む</button>
+    </div>
+  );
+};
+
+export default Timeline;

--- a/app/utils/crypto.ts
+++ b/app/utils/crypto.ts
@@ -1,0 +1,7 @@
+export async function sha256(data: ArrayBuffer | string): Promise<string> {
+  if (typeof data === 'string') {
+    data = new TextEncoder().encode(data);
+  }
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hash)).map(x => x.toString(16).padStart(2, '0')).join('');
+}

--- a/app/utils/xml.ts
+++ b/app/utils/xml.ts
@@ -1,0 +1,12 @@
+import { XMLParser, XMLBuilder } from 'fast-xml-parser';
+
+const parser = new XMLParser({ ignoreAttributes: false });
+const builder = new XMLBuilder({ ignoreAttributes: false });
+
+export function parseXml(xml: string): any {
+  return parser.parse(xml);
+}
+
+export function buildXml(obj: any): string {
+  return builder.build(obj);
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SlideGit</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./app/ui/App.tsx"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "powerpoint_reviewer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "echo 'No tests configured'"
+  },
+  "dependencies": {
+    "diff-match-patch": "^1.0.5",
+    "fast-xml-parser": "^4.3.4",
+    "jszip": "^3.10.1",
+    "@slack/web-api": "^7.4.0"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^4.1.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["app/**/*"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- show sample diff results and comment panel through a simple React demo
- wire Vite dev server so `npm run dev` launches the demo
- document demo usage in README

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@slack/web-api', 'react', 'jszip', and other types)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0682ece883229a09964f9b917e5c